### PR TITLE
Actually start the update once the update was started.

### DIFF
--- a/services/trigger-update-protonet.path
+++ b/services/trigger-update-protonet.path
@@ -1,8 +1,8 @@
 # ExperimentalPlatform
 [Unit]
 Description=Experimental Platform Channel Path Trigger
-After=dokku-protonet.service network-online.target
-Requires=dokku-protonet.service network-online.target
+After=network-online.target
+Requires=network-online.target
 
 [Path]
 PathModified=/etc/protonet/system/channel


### PR DESCRIPTION
A dependency failed so that the `.path` unit which triggers the update was never started. This should fix experimental-platform/platform-configure-script#7