### PR TITLE
set proper $HOME, preserve the rest of environment

### DIFF
--- a/services/dokku-rebuild-apps-protonet.service
+++ b/services/dokku-rebuild-apps-protonet.service
@@ -5,7 +5,7 @@ After=dokku-protonet.service
 Requires=dokku-protonet.service
 
 [Service]
-ExecStart=/bin/bash -c 'sleep 5 && docker exec dokku sudo -u dokku dokku ps:rebuildall'
+ExecStart=/bin/bash -c 'sleep 5 && docker exec dokku sudo -E -H -u dokku dokku ps:rebuildall'
 KillMode=none
 Type=oneshot
 


### PR DESCRIPTION
allows `dokku-rebuild-apps-protonet.service` to work properly with Dokku 0.4