### PR TITLE
remove stale socket on hw-mgr start

### DIFF
--- a/services/hardware-protonet.service
+++ b/services/hardware-protonet.service
@@ -11,6 +11,7 @@ Restart=always
 RestartSec=60s
 Type=notify
 NotifyAccess=all
+ExecStartPre=/usr/bin/rm -f /data/hardware/hardware.sock
 ExecStart=/opt/bin/systemd-docker --cgroups name=systemd run --rm \
     --name=hardware \
     --volume=/dev:/dev \


### PR DESCRIPTION
Prevents `address already in use` on hw mgr restart.