### PR TITLE
'!' is treated as an locked account but '*' isn't. So we use '*' to l…

### DIFF
--- a/services/init-protonet.service
+++ b/services/init-protonet.service
@@ -40,7 +40,7 @@ ExecStartPre=/bin/mkdir -p /etc/protonet/system/wifi/guest/
 ExecStartPre=-/bin/bash -c 'echo "busy" > /etc/protonet/system/button'
 ExecStartPre=-/bin/bash -c '[[ -d /etc/protonet/hostname ]] && rm -rf /etc/protonet/hostname'
 ExecStartPre=-/bin/bash -c '[[ ! -f /etc/protonet/hostname ]] && echo "paleale" > /etc/protonet/hostname'
-ExecStartPre=-/bin/bash -c '/usr/sbin/useradd -c "Created by init-protonet.service" -m -s /bin/false -p "!" proxytunnel'
+ExecStartPre=-/bin/bash -c '/usr/sbin/useradd -c "Created by init-protonet.service" -m -s /bin/false -p "*" proxytunnel'
 ExecStart=/usr/bin/env true
 
 [Install]


### PR DESCRIPTION
…ock account against password-guessing attacks.
