### PR TITLE
Soul unix socket cleanup

### DIFF
--- a/services/soul-dispatcher.service
+++ b/services/soul-dispatcher.service
@@ -26,7 +26,7 @@ ExecStart=/opt/bin/systemd-docker --cgroups name=systemd run --rm \
   --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
   --volume /data/samba/etc:/etc/samba/ \
   --volume /data/samba/extrausers:/var/lib/extrausers/ \
-  --volume /data/hardware/hardware.sock:/tmp/hardware.sock \
+  --volume /data/hardware:/tmp/hardware \
   experimentalplatform/german-shepherd:development \
   bundle exec foreman start dispatcher
 

--- a/services/soul-prepare.service
+++ b/services/soul-prepare.service
@@ -23,7 +23,7 @@ ExecStartPre=/opt/bin/systemd-docker --cgroups name=systemd run --rm \
                --volume /data/soul/log:/home/protonet/dashboard/shared/log/ \
                --volume /data/soul/public:/home/protonet/dashboard/shared/public/ \
                --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
-               --volume /data/hardware/hardware.sock:/tmp/hardware.sock \
+               --volume /data/hardware:/tmp/hardware \
                experimentalplatform/german-shepherd:development \
                bundle exec rake docker:prepare
 ExecStart=/usr/bin/env true

--- a/services/soul-web.service
+++ b/services/soul-web.service
@@ -28,8 +28,8 @@ ExecStart=/opt/bin/systemd-docker --cgroups name=systemd run --rm \
       --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
       --volume /data/samba/etc:/etc/samba/ \
       --volume /data/samba/extrausers:/var/lib/extrausers/ \
-      --volume /data/hardware/hardware.sock:/tmp/hardware.sock \
-      --volume /data/soul-backup/socket:/tmp/backup.sock \
+      --volume /data/hardware:/tmp/hardware \
+      --volume /data/soul-backup:/tmp/backup \
       experimentalplatform/german-shepherd:development \
       bundle exec foreman start web
 

--- a/services/soul-worker.service
+++ b/services/soul-worker.service
@@ -29,8 +29,8 @@ ExecStart=/opt/bin/systemd-docker --cgroups name=systemd run --rm \
     --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
     --volume /data/samba/etc:/etc/samba/ \
     --volume /data/samba/extrausers:/var/lib/extrausers/ \
-    --volume /data/hardware/hardware.sock:/tmp/hardware.sock \
-    --volume /data/soul-backup/socket:/tmp/backup.sock \
+    --volume /data/hardware:/tmp/hardware \
+    --volume /data/soul-backup:/tmp/backup \
     experimentalplatform/german-shepherd:development \
     bundle exec foreman start worker
 


### PR DESCRIPTION
Mount parent directories instead of actual sockets to avoid stir-ups with docker volumes (when docker creates a folder on volume mount at the host location of the socket file)
