### PR TITLE
Major Refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
-sudo: required
+sudo: false
 services:
   - docker
 
-script:
-  - npm install -g mustache
-# building PRs with shell scripts is a credential leak vulnerability
-  - >
-    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-      ./ci-build.sh
-      SERVICE_TAG=${SERVICE_TAG:-$TRAVIS_BRANCH}; docker build -t experimentalplatform/configure:${SERVICE_TAG} .
-      if [ "$TRAVIS_BRANCH" == "master" ]; then
-        echo -e "\n\nWe're not uploading master anywhere."
-      else
-        docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-        SERVICE_TAG=${SERVICE_TAG:-$TRAVIS_BRANCH}; docker push experimentalplatform/configure:${SERVICE_TAG}
-      fi
-    fi
+install:
+  - 'npm install -g mustache'
+  - 'SERVICE_TAG=${SERVICE_TAG:-$TRAVIS_BRANCH}'
+  - './ci-build.sh'
+  - 'docker build -t experimentalplatform/configure:${SERVICE_TAG} .'
 
+script:
+  - 'docker run --rm experimentalplatform/configure:${SERVICE_TAG} /test.sh'
+
+after_success:
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "$TRAVIS_BRANCH" != "master" ] && DEPLOY=true || DEPLOY=false'
+  - '[ "${DEPLOY}" = "true" ] && docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS'
+  - '[ "${DEPLOY}" = "true" ] && docker push experimentalplatform/configure:${SERVICE_TAG}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM experimentalplatform/ubuntu:latest
 
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install --no-install-recommends gawk systemd && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 ADD services /services
 ADD config /config
 ADD prep.sh /prep.sh
+ADD test.sh /test.sh
 ADD scripts /scripts
 ADD button /button
 

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -43,4 +43,8 @@ done
 
 
 # Download current version of platform-configure.sh
-curl -f https://raw.githubusercontent.com/experimental-platform/platform-configure-script/master/platform-configure.sh > scripts/platform-configure.sh
+echo -e "\n\nAdding 'platform-configure-script' with VERSION 'development':"
+curl -f https://raw.githubusercontent.com/experimental-platform/platform-configure-script/development/platform-configure.sh > scripts/platform-configure.sh
+
+
+echo -e "\n\n\nALL DONE.\n\n\n"

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -44,7 +44,7 @@ done
 
 # Download current version of platform-configure.sh
 echo -e "\n\nAdding 'platform-configure-script' with VERSION 'development':"
-curl -f https://raw.githubusercontent.com/experimental-platform/platform-configure-script/development/platform-configure.sh > scripts/platform-configure.sh
+curl -f https://raw.githubusercontent.com/experimental-platform/platform-configure-script/master/platform-configure.sh > scripts/platform-configure.sh
 
 
 echo -e "\n\n\nALL DONE.\n\n\n"

--- a/prep.sh
+++ b/prep.sh
@@ -49,14 +49,6 @@ function setup_systemd() {
     find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 -name "*.path" -type f | \
         xargs --no-run-if-empty basename -a | \
         xargs --no-run-if-empty systemctl restart
-    # timers need to be enabled
-    find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 -name "*.timer" -type f | \
-        xargs --no-run-if-empty basename -a | \
-        xargs --no-run-if-empty systemctl --root=${MOUNTROOT} enable
-    # socket units need to be enabled, if any exist
-    find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 -name "*.socket" -type f | \
-        xargs --no-run-if-empty basename -a | \
-        xargs --no-run-if-empty systemctl --root=${MOUNTROOT} enable
 }
 
 

--- a/prep.sh
+++ b/prep.sh
@@ -39,7 +39,7 @@ function setup_systemd() {
     cp /config/*.network  ${MOUNTROOT}/etc/systemd/network
     # Make sure we're actually waiting for the network if it's required.
     systemctl --root=${MOUNTROOT} enable systemd-networkd-wait-online.service
-    find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 ! -name "*.sh" -type f \
+    find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 ! -name "*.sh" -type f | \
         xargs --no-run-if-empty basename -a | \
         xargs --no-run-if-empty systemctl --root=${MOUNTROOT} enable
     # .path files need to be started!

--- a/prep.sh
+++ b/prep.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -x
 
 MOUNTROOT=${MOUNTROOT:="/mnt"}
 DOCKER=$(which docker)
@@ -63,10 +62,10 @@ function setup_channel_file() {
     # TODO: Bail if either CHANNEL or CHANNEL_FILE are not set
     if [[ ! -f ${CHANNEL_FILE} ]] || [[ ! $(cat ${CHANNEL_FILE}) = "${CHANNEL}" ]]; then
         echo "NEW channel is '${CHANNEL}'."
-        systemctl --root=${MOUNTROOT} stop trigger-update-protonet.path
+        systemctl stop trigger-update-protonet.path
         mkdir -p $(dirname ${CHANNEL_FILE})
         echo ${CHANNEL} > ${CHANNEL_FILE}
-        systemctl --root=${MOUNTROOT} start trigger-update-protonet.path
+        systemctl start trigger-update-protonet.path
     else
         echo "Keeping old channel '${CHANNEL}'."
     fi

--- a/prep.sh
+++ b/prep.sh
@@ -2,7 +2,6 @@
 set -e
 
 MOUNTROOT=${MOUNTROOT:="/mnt"}
-DOCKER=$(which docker)
 
 
 function set_status() {
@@ -79,6 +78,7 @@ function download_and_verify_image() {
     # TODO: Bail if IMAGE_STATE_DIR or REGISTRY is not set
     echo -ne "\t Image ${image}..."
     local image=$1
+    DOCKER=$(which docker)
     ${DOCKER} tag -f ${image} "${image}-previous" 2>/dev/null || true # do not fail, this is just for backup reason
     ${DOCKER} pull ${image}
 

--- a/prep.sh
+++ b/prep.sh
@@ -105,24 +105,6 @@ function download_and_verify_image() {
 }
 
 
-function update_os_image() {
-    set_status "osupdate"
-    # run update and save its exit code
-    echo "Forcing system image update"
-    update_engine_client -update &>/dev/null | true
-    update_status=${PIPESTATUS[0]}
-    echo "Done."
-
-    if [[ "$update_status" -eq 0 ]]; then
-        echo "System image update successfull."
-        return 0
-    else
-        echo "System image update failed."
-        return 1
-    fi
-}
-
-
 function setup_images() {
     # Pre-Fetch all Images
     # When using a feature branch most images come from the development channel:
@@ -199,7 +181,6 @@ function setup_utility_scripts () {
 # FIRST: Update the platform-configure.script itself!
 setup_utility_scripts
 # Now the stuff that may break...
-enable_os_updates
 setup_paths
 cleanup_systemd
 setup_udev

--- a/prep.sh
+++ b/prep.sh
@@ -123,36 +123,6 @@ function update_os_image() {
 }
 
 
-function enable_os_updates() {
-    # TODO: Bail if either PLATFORM_SYS_GROUP or UPDATE_ENGINE_CONFIG or  are not set
-    if [[ -z "${PLATFORM_SYS_GROUP}" ]]; then
-        if [ -e ${UPDATE_ENGINE_CONFIG} ]; then
-            PLATFORM_SYS_GROUP=$(cat ${UPDATE_ENGINE_CONFIG} | grep '^GROUP=' | cut -f2 -d '=')
-            echo "Using OS group '${PLATFORM_SYS_GROUP}' from ${UPDATE_ENGINE_CONFIG}."
-        else
-            PLATFORM_SYS_GROUP="protonet"
-            echo "No OS group given. Using '${PLATFORM_SYS_GROUP}' (default group)."
-        fi
-    else
-        echo "Using OS group '${PLATFORM_SYS_GROUP}' from the command line."
-    fi
-
-    # reset backoff timestamp
-    rm -f ${MOUNTROOT}/var/lib/update_engine/prefs/backoff-expiry-time
-
-    # configure update source
-    echo | tee ${MOUNTROOT}/etc/coreos/update.conf &>/dev/null <<- EOM
-GROUP=${PLATFORM_SYS_GROUP}
-SERVER=https://coreos-update.protorz.net/update
-REBOOT_STRATEGY=off
-EOM
-
-	# apply changes to update-engine
-	systemctl restart update-engine.service
-}
-
-
-
 function setup_images() {
     # Pre-Fetch all Images
     # When using a feature branch most images come from the development channel:

--- a/prep.sh
+++ b/prep.sh
@@ -2,12 +2,12 @@
 set -e
 set -x
 
-MOUNTROOT=/mnt
+MOUNTROOT=${MOUNTROOT:="/mnt"}
 DOCKER=$(which docker)
 
 
 function set_status() {
-  mkdir -p /etc/protonet/system
+  mkdir -p ${MOUNTROOT}/etc/protonet/system
   echo "$@" > ${MOUNTROOT}/etc/protonet/system/configure-script-status
 }
 
@@ -88,7 +88,7 @@ function download_and_verify_image() {
             # This is the most stupid way to check if all layer were downloaded correctly.
             # But it is the fastest one. The docker save command takes about 30 Minutes for all images,
             # even with output piped to /dev/null.
-            if [[ ! -e /var/lib/docker/overlay/${layer} || ! -e /var/lib/docker/graph/${layer} ]]; then
+            if [[ ! -e ${MOUNTROOT}/var/lib/docker/overlay/${layer} || ! -e ${MOUNTROOT}/var/lib/docker/graph/${layer} ]]; then
                 ${DOCKER} tag -f "${image}-previous" ${image} 2>/dev/null
                 # TODO: return instead?
                 exit 1

--- a/prep.sh
+++ b/prep.sh
@@ -37,12 +37,15 @@ function setup_systemd() {
     cp /config/journald_protonet.conf ${MOUNTROOT}/etc/systemd/journald.conf.d/journald_protonet.conf
     # Network configuration
     cp /config/*.network  ${MOUNTROOT}/etc/systemd/network
+    echo "Reloading the config files."
+    systemctl daemon-reload
     # Make sure we're actually waiting for the network if it's required.
     systemctl --root=${MOUNTROOT} enable systemd-networkd-wait-online.service
+    echo "ENABLing all config files."
     find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 ! -name "*.sh" -type f | \
         xargs --no-run-if-empty basename -a | \
         xargs --no-run-if-empty systemctl --root=${MOUNTROOT} enable
-    # .path files need to be started!
+    echo "RESTARTing all .path files."
     find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 -name "*.path" -type f | \
         xargs --no-run-if-empty basename -a | \
         xargs --no-run-if-empty systemctl restart

--- a/prep.sh
+++ b/prep.sh
@@ -184,7 +184,7 @@ function setup_utility_scripts () {
         fi
         echo "DONE."
     done
-    cp /button ${MOUNTROOT}/opt/bin/
+    cp /button ${BIN_PATH}
     echo "ALL DONE"
 }
 

--- a/prep.sh
+++ b/prep.sh
@@ -1,46 +1,238 @@
 #!/bin/bash
 set -e
+set -x
 
-# new systems need sometimes dont have systemd/system/
-mkdir -p /data/systemd/system/
-# First remove broken links, this should avoid confusing error messages
-find -L /data/systemd/system/ -type l -exec rm -f {} +
-grep -Hlr '# ExperimentalPlatform' /data/systemd/system/ | xargs rm -rf
-# do it again to remove garbage
-find -L /data/systemd/system/ -type l -exec rm -f {} +
+MOUNTROOT=/mnt
+DOCKER=$(which docker)
 
-cp /services/* /data/systemd/system/
 
-mkdir -p /data/systemd/system/docker.service.d
-cp /config/50-log-warn.conf /data/systemd/system/docker.service.d/50-log-warn.conf
+function set_status() {
+  mkdir -p /etc/protonet/system
+  echo "$@" > ${MOUNTROOT}/etc/protonet/system/configure-script-status
+}
 
-# Network configuration
-grep -Hlr '# ExperimentalPlatform' /data/systemd/network | xargs rm -rf
-cp /config/*.network  /data/systemd/network
 
-mkdir -p /data/udev/rules.d
-cp /config/sound-permissions.rules /data/udev/rules.d/sound-permissions.rules
-cp /config/video-permissions.rules /data/udev/rules.d/video-permissions.rules
-cp /config/tty-permissions.rules   /data/udev/rules.d/tty-permissions.rules
-cp /config/80-protonet.rules       /data/udev/rules.d/80-protonet.rules
+function setup_paths() {
+    # new systems need sometimes dont have systemd/system/
+    mkdir -p ${MOUNTROOT}/etc/systemd/journald.conf.d
+    mkdir -p ${MOUNTROOT}/etc/systemd/system/
+    mkdir -p ${MOUNTROOT}/etc/systemd/system/docker.service.d
+    mkdir -p ${MOUNTROOT}/etc/systemd/system/scripts/
+    mkdir -p ${MOUNTROOT}/etc/udev/rules.d
+}
 
-# Automates installation of utility scripts and services from scripts/* into
-# $PATH on target systems.
-mkdir -p /data/systemd/system/scripts/
-for f in scripts/*.sh
-do
-  name=$(basename $f .sh)
-  dest=/data/systemd/system/scripts/$name.sh
-  echo "Installing $name to $dest"
 
-  cp /scripts/$name.sh $dest
-  chmod +x $dest
-  if [ -d /host-bin/ ]; then
-    # this needs to be the full path on host, not in container
-    ln -sf /etc/systemd/system/scripts/$name.sh /host-bin/$name
-  fi
-done
+function cleanup_systemd() {
+    # First remove broken links, this should avoid confusing error messages
+    find -L ${MOUNTROOT}/etc/systemd/system/ -type l -exec rm -f {} +
+    grep -Hlr '# ExperimentalPlatform' ${MOUNTROOT}/etc/systemd/system/ | xargs rm -rf
+    # do it again to remove garbage
+    find -L ${MOUNTROOT}/etc/systemd/system/ -type l -exec rm -f {} +
+    grep -Hlr '# ExperimentalPlatform' ${MOUNTROOT}/etc/systemd/network | xargs rm -rf
+}
 
-cp /button /host-bin/
 
-mkdir -p /data/systemd/journald.conf.d && cp /config/journald_protonet.conf /data/systemd/journald.conf.d/journald_protonet.conf
+function setup_systemd() {
+    cp /services/* ${MOUNTROOT}/etc/systemd/system/
+    cp /config/50-log-warn.conf ${MOUNTROOT}/etc/systemd/system/docker.service.d/50-log-warn.conf
+    cp /config/journald_protonet.conf ${MOUNTROOT}/etc/systemd/journald.conf.d/journald_protonet.conf
+    # Network configuration
+    cp /config/*.network  ${MOUNTROOT}/etc/systemd/network
+    # Make sure we're actually waiting for the network if it's required.
+    systemctl --root=${MOUNTROOT} enable systemd-networkd-wait-online.service
+    find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 ! -name "*.sh" -type f \
+        xargs --no-run-if-empty basename -a | \
+        xargs --no-run-if-empty systemctl --root=${MOUNTROOT} enable
+    # .path files need to be started!
+    find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 -name "*.path" -type f | \
+        xargs --no-run-if-empty basename -a | \
+        xargs --no-run-if-empty systemctl restart
+    # timers need to be enabled
+    find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 -name "*.timer" -type f | \
+        xargs --no-run-if-empty basename -a | \
+        xargs --no-run-if-empty systemctl --root=${MOUNTROOT} enable
+    # socket units need to be enabled, if any exist
+    find ${MOUNTROOT}/etc/systemd/system -maxdepth 1 -name "*.socket" -type f | \
+        xargs --no-run-if-empty basename -a | \
+        xargs --no-run-if-empty systemctl --root=${MOUNTROOT} enable
+}
+
+
+function setup_channel_file() {
+    # update the channel file in case there's none or if we're changing channels.
+    # TODO: Bail if either CHANNEL or CHANNEL_FILE are not set
+    if [[ ! -f ${CHANNEL_FILE} ]] || [[ ! $(cat ${CHANNEL_FILE}) = "${CHANNEL}" ]]; then
+        echo "NEW channel is '${CHANNEL}'."
+        systemctl --root=${MOUNTROOT} stop trigger-update-protonet.path
+        mkdir -p $(dirname ${CHANNEL_FILE})
+        echo ${CHANNEL} > ${CHANNEL_FILE}
+        systemctl --root=${MOUNTROOT} start trigger-update-protonet.path
+    else
+        echo "Keeping old channel '${CHANNEL}'."
+    fi
+}
+
+
+function download_and_verify_image() {
+    # TODO: DUPLICATED CODE MARK
+    # TODO: Bail if IMAGE_STATE_DIR or REGISTRY is not set
+    local image=$1
+    ${DOCKER} tag -f ${image} "${image}-previous" 2>/dev/null || true # do not fail, this is just for backup reason
+    ${DOCKER} pull ${image}
+
+    local driver=$(${DOCKER} info | grep '^Storage Driver: ' | sed -r 's/^Storage Driver: (.*)/\1/')
+    # if using OverlayFS then verify layers
+    if [ "${driver}" == "overlay" ]; then
+        # TODO: this basically works with ZFS too, it just has slightly different path names
+        for layer in $(docker history --no-trunc ${image} | tail -n +2 | awk '{ print $1 }'); do
+            # This is the most stupid way to check if all layer were downloaded correctly.
+            # But it is the fastest one. The docker save command takes about 30 Minutes for all images,
+            # even with output piped to /dev/null.
+            if [[ ! -e /var/lib/docker/overlay/${layer} || ! -e /var/lib/docker/graph/${layer} ]]; then
+                ${DOCKER} tag -f "${image}-previous" ${image} 2>/dev/null
+                # TODO: return instead?
+                exit 1
+            fi
+        done
+    fi
+
+    # TODO: Might wanna add --type=image for good measure once Docker 1.8 hits the CoreOS stable.
+    local image_id=$(docker inspect --format '{{.Id}}' ${image})
+    image=${image#$REGISTRY/} # remove Registry prefix
+
+    mkdir -p $(dirname ${IMAGE_STATE_DIR}/${image})
+    echo $image_id > ${IMAGE_STATE_DIR}/${image}
+}
+
+
+function update_os_image() {
+    set_status "osupdate"
+    # run update and save its exit code
+    echo "Forcing system image update"
+    update_engine_client -update &>/dev/null | true
+    update_status=${PIPESTATUS[0]}
+    echo "Done."
+
+    if [[ "$update_status" -eq 0 ]]; then
+        echo "System image update successfull."
+        return 0
+    else
+        echo "System image update failed."
+        return 1
+    fi
+}
+
+
+function enable_os_updates() {
+    # TODO: Bail if either PLATFORM_SYS_GROUP or UPDATE_ENGINE_CONFIG or  are not set
+    if [[ -z "${PLATFORM_SYS_GROUP}" ]]; then
+        if [ -e ${UPDATE_ENGINE_CONFIG} ]; then
+            PLATFORM_SYS_GROUP=$(cat ${UPDATE_ENGINE_CONFIG} | grep '^GROUP=' | cut -f2 -d '=')
+            echo "Using OS group '${PLATFORM_SYS_GROUP}' from ${UPDATE_ENGINE_CONFIG}."
+        else
+            PLATFORM_SYS_GROUP="protonet"
+            echo "No OS group given. Using '${PLATFORM_SYS_GROUP}' (default group)."
+        fi
+    else
+        echo "Using OS group '${PLATFORM_SYS_GROUP}' from the command line."
+    fi
+
+    # reset backoff timestamp
+    rm -f ${MOUNTROOT}/var/lib/update_engine/prefs/backoff-expiry-time
+
+    # configure update source
+    echo | tee ${MOUNTROOT}/etc/coreos/update.conf &>/dev/null <<- EOM
+GROUP=${PLATFORM_SYS_GROUP}
+SERVER=https://coreos-update.protorz.net/update
+REBOOT_STRATEGY=off
+EOM
+
+	# apply changes to update-engine
+	systemctl restart update-engine.service
+}
+
+
+
+function setup_images() {
+    # Pre-Fetch all Images
+    # When using a feature branch most images come from the development channel:
+    available_channels="development alpha beta stable"
+    if [[ ! ${available_channels} =~ ${CHANNEL} ]]; then
+        echo "We're on feature channel '${CHANNEL}'"
+        CHANNEL=development
+    fi
+
+    # prefetch buildstep. so the first deployment doesn't have to fetch it.
+    download_and_verify_image experimentalplatform/buildstep:herokuish
+    # Complex regexp to find all images names in all service files
+    IMAGES=$(gawk '!/^\s*[a-zA-Z0-9]+=|\[|^#|^\s*$|^\s*\-|^\s*bundle/ { sub("[^a-zA-Z0-9/:@.-]", "", $1); print $1}' ${MOUNTROOT}/etc/systemd/system/*.service | sort | uniq)
+    IMG_NUMBER=$(echo "${IMAGES}" | wc -l)
+    IMG_COUNT=0
+    for IMAGE in ${IMAGES}; do
+        set_status "image $IMG_COUNT/$IMG_NUMBER"
+        # download german-shepherd and soul ony if soul is enabled.
+        if [[ "experimentalplatform/german-shepherd experimentalplatform/soul-nginx" =~ ${IMAGE%:*} ]]; then
+            if [[ -f "${MOUNTROOT}/etc/protonet/soul/enabled" ]]; then
+                download_and_verify_image ${IMAGE}
+            fi
+        else
+            download_and_verify_image ${IMAGE}
+        fi
+        IMG_COUNT=$((IMG_COUNT+1))
+    done
+    set_status "finalizing"
+    if [ "$PLATFORM_INSTALL_RELOAD" = true ]; then
+        echo "Reloading systemctl after update."
+        systemctl restart init-protonet.service
+        exit 0
+    fi
+    if [ "$PLATFORM_INSTALL_OSUPDATE" = true ]; then
+        echo "Updating CoreOS system image."
+        update_os_image || true
+    fi
+
+    echo "===================================================================="
+    echo "After the reboot your experimental platform will be reachable via:"
+    echo "http://$(cat $HOSTNAME_FILE).local"
+    echo "(don't worry, you can change this later)"
+    echo "===================================================================="
+
+}
+
+
+function setup_udev() {
+    cp /config/sound-permissions.rules ${MOUNTROOT}/etc/udev/rules.d/sound-permissions.rules
+    cp /config/video-permissions.rules ${MOUNTROOT}/etc/udev/rules.d/video-permissions.rules
+    cp /config/tty-permissions.rules   ${MOUNTROOT}/etc/udev/rules.d/tty-permissions.rules
+    cp /config/80-protonet.rules       ${MOUNTROOT}/etc/udev/rules.d/80-protonet.rules
+}
+
+
+function setup_utility_scripts () {
+    # Automates installation of utility scripts and services from scripts/* into
+    # $PATH on target systems.
+    for f in scripts/*.sh; do
+      name=$(basename ${f} .sh)
+      dest=${MOUNTROOT}/etc/systemd/system/scripts/${name}.sh
+      echo "Installing ${name} to ${dest}"
+
+      cp /scripts/${name}.sh ${dest}
+      chmod +x ${dest}
+      if [ -d ${MOUNTROOT}/opt/bin/ ]; then
+        # this needs to be the full path on host, not in container
+        ln -sf /etc/systemd/system/scripts/${name}.sh ${MOUNTROOT}/opt/bin/${name}
+      fi
+    done
+    cp /button ${MOUNTROOT}/opt/bin/
+}
+
+# FIRST: Update the platform-configure.script itself!
+setup_utility_scripts
+# Now the stuff that may break...
+enable_os_updates
+setup_paths
+cleanup_systemd
+setup_udev
+setup_systemd
+setup_channel_file
+setup_images

--- a/scripts/update_os.sh
+++ b/scripts/update_os.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -e
+
+
+# Copyright 2015 Protonet GmbH
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+function set_variables() {
+    PLATFORM_BASENAME=${PLATFORM_BASENAME:=""}
+    UPDATE_CONF=${PLATFORM_BASENAME}/etc/coreos/update.conf
+    UPDATE_ENGINE_CONFIG=${PLATFORM_BASENAME}/etc/coreos/update.conf
+    PROTONET_PUBKEY="-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5CfJQVP2yJlcMu/3/RxD
+KnOvcxD40VWsDiUn/FDXlcgQWpg/xH2a7LD9bpD4c3+jWtUst+I7ZhL11YiyfQDr
+Afw9m11RiHtl+fvJfLg8PwuQ25jc5Cf/hLn+NpnFxL4vlifNWljIoIh17j3KE0hj
+jd/V7435gkIm0eIvTiebn4cposzh74XrlOnsGyTTyPJ4IMcnS3zYdOIAeTKoSMea
+rUIsXC8jYMQtua8q96eqM3bPsvFLBWRRQoTfRtVSfydNbZp+i1SixVKo4oDz9UmF
+fNLAJRPgRI+pXV0O6MdmPtKu5dQNkVGAYm7RWbxZctGxsOArXE43OjqE6kGLVabw
+7QIDAQAB
+-----END PUBLIC KEY-----"
+}
+
+
+function is_update_key_protonet() {
+    key_path="${PLATFORM_BASENAME}/usr/share/update_engine/update-payload-key.pub.pem"
+    current_digest=$(cat "$key_path" | sha1sum | cut -f1 -d ' ')
+    protonet_digest=$(echo "$PROTONET_PUBKEY" | sha1sum | cut -f1 -d ' ')
+    if [[ "$current_digest" == "$protonet_digest" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+
+function prepare_os_update() {
+	# in case there was an automatic update already running
+	update_engine_client -reset_status
+
+	# just in case someone left a key mount
+    umount ${PLATFORM_BASENAME}/usr/share/update_engine/update-payload-key.pub.pem &>/dev/null || true
+	if ! is_update_key_protonet; then
+        echo "$PROTONET_PUBKEY" > ${PLATFORM_BASENAME}/tmp/protonet-image.pub.pem
+        mount --bind ${PLATFORM_BASENAME}/tmp/protonet-image.pub.pem ${PLATFORM_BASENAME}/usr/share/update_engine/update-payload-key.pub.pem
+  fi
+}
+
+
+function enable_os_updates() {
+    # TODO: Bail if either PLATFORM_SYS_GROUP or UPDATE_ENGINE_CONFIG or  are not set
+    if [[ -z "${PLATFORM_SYS_GROUP}" ]]; then
+        if [ -e ${UPDATE_ENGINE_CONFIG} ]; then
+            PLATFORM_SYS_GROUP=$(cat ${UPDATE_ENGINE_CONFIG} | grep '^GROUP=' | cut -f2 -d '=')
+            echo "Using OS group '${PLATFORM_SYS_GROUP}' from ${UPDATE_ENGINE_CONFIG}."
+        else
+            PLATFORM_SYS_GROUP="protonet"
+            echo "No OS group given. Using '${PLATFORM_SYS_GROUP}' (default group)."
+        fi
+    else
+        echo "Using OS group '${PLATFORM_SYS_GROUP}' from the command line."
+    fi
+
+    # reset backoff timestamp
+    rm -f ${PLATFORM_BASENAME}/var/lib/update_engine/prefs/backoff-expiry-time
+
+    # configure update source
+    echo | tee ${UPDATE_CONF} &>/dev/null <<- EOM
+GROUP=${PLATFORM_SYS_GROUP}
+SERVER=https://coreos-update.protorz.net/update
+REBOOT_STRATEGY=off
+EOM
+
+	# apply changes to update-engine
+	systemctl restart update-engine.service
+
+    # in case we mounted a downloaded key
+    umount ${PLATFORM_BASENAME}/usr/share/update_engine/update-payload-key.pub.pem &>/dev/null || true
+    rm -f ${PLATFORM_BASENAME}/tmp/protonet-image.pub.pem || true
+}
+
+set_variables
+prepare_os_update
+enable_os_updates

--- a/scripts/update_os.sh
+++ b/scripts/update_os.sh
@@ -89,6 +89,25 @@ EOM
     rm -f ${PLATFORM_BASENAME}/tmp/protonet-image.pub.pem || true
 }
 
+function update_os_image() {
+    # run update and save its exit code
+    echo "Forcing system image update"
+    update_engine_client -update &>/dev/null | true
+    update_status=${PIPESTATUS[0]}
+    echo "Done."
+
+    if [[ "$update_status" -eq 0 ]]; then
+        echo "System image update successfull."
+        return 0
+    else
+        echo "System image update failed."
+        return 1
+    fi
+}
+
+
+
 set_variables
 prepare_os_update
 enable_os_updates
+update_os_image

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 set -e
 set -x
 
-grep -q '{{tag}}' /system/*.{service,timer} && exit 1 || true
+grep -q '{{tag}}' /services/*.{service,timer} && exit 1 || true

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+set -x
+
+grep -q '{{tag}}' /system/*.{service,timer} && exit 1 || true


### PR DESCRIPTION
**This pull request depends on https://github.com/experimental-platform/platform-configure-script/pull/78 – coordinated merge only!**

Major refactoring:
- gets most of the functionality from https://github.com/experimental-platform/platform-configure-script/pull/78
- moves everything into subroutines
- uses a singular generic mount point
- uses `systemctl` from within the container
- makes chained `systemctl` calls more robust
- Uses gawk instead of awk, because this is the default on CoreOS
- cleans up `.travis.yml`
- adds a primitive test function
