### PR TITLE
wait for ZFS before creating 'soul-backup' socket

### DIFF
--- a/services/soul-backup.socket
+++ b/services/soul-backup.socket
@@ -2,6 +2,7 @@
 [Unit]
 Description=Protonet Soul backup Service
 ConditionPathExists=/etc/protonet/soul/enabled
+After=zfs.service
 
 [Socket]
 ExecStartPre=/bin/mkdir -p /data/soul-backup


### PR DESCRIPTION
Should prevent the unit from running on bare `/data` mountpoint.
