### PR TITLE
We don't use the hostname but the box_name instead, so we don't need …

### DIFF
--- a/services/hostapd-restart-protonet.path
+++ b/services/hostapd-restart-protonet.path
@@ -8,7 +8,6 @@ PathModified=/etc/protonet/system/wifi/password
 PathModified=/etc/protonet/system/wifi/channel
 PathModified=/etc/protonet/system/wifi/guest/enabled
 PathModified=/etc/protonet/system/wifi/guest/password
-PathModified=/etc/protonet/hostname
 PathModified=/etc/protonet/box_name
 
 [Install]


### PR DESCRIPTION
…to restart on hostname changes any more. [Fixes #119084249]
