### PR TITLE
In most cases there's no IPMI available, which equals a safe IPMI config [#121112699]

### DIFF
--- a/scripts/test-ipmi-disabled.sh
+++ b/scripts/test-ipmi-disabled.sh
@@ -2,12 +2,16 @@
 
 set -eu
 echo -n "RUNNING IPMI SECURITY TEST... "
-enabled_user_count=$(ipmitool user summary | grep 'Enabled User Count' | grep --only-matching '[0-9]*$')
 
-if [ $enabled_user_count -eq 0 ]; then
-	echo "OKAY, IPMI users are disabled"
-	exit 0
+if [[ -e /dev/ipmi0 ]] || [[ -e /dev/ipmi/0 ]] || [[ -e /dev/ipmidev/0 ]]; then
+    enabled_user_count=$(ipmitool user summary | grep 'Enabled User Count' | grep --only-matching '[0-9]*$')
+
+    if [ $enabled_user_count -eq 0 ]; then
+        echo "OKAY, IPMI users are disabled"
+    else
+        echo "ERROR: There are $enabled_user_count IPMI users enabled"
+        exit 1
+    fi
 else
-	echo "ERROR: There are $enabled_user_count IPMI users enabled"
-	exit 1
+    echo "OKAY, IPMI NOT AVAILABLE."
 fi


### PR DESCRIPTION
In most cases there's no IPMI available, which equals a safe IPMI config and should return exit code 0.
