### PR TITLE
enable pipefail in prep.sh

### DIFF
--- a/prep.sh
+++ b/prep.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
 MOUNTROOT=${MOUNTROOT:="/mnt"}
 CHANNEL=${CHANNEL:="development"}


### PR DESCRIPTION
prevents the script from continuing e.g. when fetching channel manifest fails
