### PR TITLE
Gitlab Network wiring

### DIFF
--- a/services/gitlab-network-ip.service
+++ b/services/gitlab-network-ip.service
@@ -1,0 +1,10 @@
+# ExperimentalPlatform
+[Unit]
+Description=Write out current gitlab virtual network IP address to SKVS/FS
+Requires=gitlab.service
+After=gitlab.service
+
+[Service]
+KillMode=none
+Type=oneshot
+ExecStart=/usr/bin/env bash -c '/opt/bin/gitlab-network show > /etc/protonet/gitlab/ip'

--- a/services/gitlab-network-ip.timer
+++ b/services/gitlab-network-ip.timer
@@ -1,0 +1,11 @@
+# ExperimentalPlatform
+[Unit]
+Description=Run gitlab-network-ip.service periodically
+Requires=gitlab.service
+After=gitlab.service
+
+[Timer]
+OnUnitActiveSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/services/gitlab.service
+++ b/services/gitlab.service
@@ -9,6 +9,7 @@ TimeoutStartSec=0
 TimeoutStopSec=15
 Restart=always
 RestartSec=5s
+ExecStartPre=/opt/bin/gitlab-network start
 ExecStartPre=-/usr/bin/docker rm -f gitlab
 ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
     --name gitlab \

--- a/services/platform-haproxy-restart-on-gitlab-change.path
+++ b/services/platform-haproxy-restart-on-gitlab-change.path
@@ -1,0 +1,9 @@
+# ExperimentalPlatform
+[Unit]
+Description=Trigger a Restart of HAProxy if the gitlab IP address changes
+
+[Path]
+PathChanged=/etc/protonet/gitlab/ip
+
+[Install]
+WantedBy=multi-user.target

--- a/services/platform-haproxy-restart-on-gitlab-change.service
+++ b/services/platform-haproxy-restart-on-gitlab-change.service
@@ -1,0 +1,10 @@
+# ExperimentalPlatform
+[Unit]
+Description=Restart HAProxy when Gitlab IP address changed
+After=platform-haproxy.service
+Requires=platform-haproxy.service
+
+[Service]
+ExecStart=/usr/bin/env systemctl restart platform-haproxy.service
+KillMode=none
+Type=oneshot


### PR DESCRIPTION
- Write current gitlab network IP regularly to SKVS and FS (ideally this should be replaced with actual network events on this specific interface)
- Trigger a restart of HAProxy on changes of the ip (like enabling gitlab, disabling it, or DHCP network changes)
- Start the gitlab network on startup of the gitlab unit - will only happen if gitlab is enabled as per the dependency tree

Follows https://github.com/experimental-platform/platform-haproxy/pull/6 and https://github.com/experimental-platform/platform-configure/pull/210

Pivotal: https://www.pivotaltracker.com/story/show/116044571
