### PR TITLE
Fixes for Gitlab IP wiring and restarting HAProxy

### DIFF
--- a/scripts/gitlab-network-ip.sh
+++ b/scripts/gitlab-network-ip.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Write out gitlab-network ip to SKVS if it has changed
+if [ "$(/opt/bin/gitlab-network show | md5sum)" != "$(cat /etc/protonet/gitlab/ip | md5sum)" ]; then
+  /opt/bin/gitlab-network show > /etc/protonet/gitlab/ip
+  echo "Wrote gitlab-network ip to SKVS since it changed"
+fi

--- a/services/gitlab-network-ip.service
+++ b/services/gitlab-network-ip.service
@@ -1,10 +1,10 @@
 # ExperimentalPlatform
 [Unit]
-Description=Write out current gitlab virtual network IP address to SKVS/FS
+Description=Write out current gitlab virtual network IP address to SKVS/FS if it has changed
 Requires=gitlab.service
 After=gitlab.service
 
 [Service]
 KillMode=none
 Type=oneshot
-ExecStart=/usr/bin/env bash -c '/opt/bin/gitlab-network show > /etc/protonet/gitlab/ip'
+ExecStart=/opt/bin/gitlab-network-ip

--- a/services/gitlab-network-ip.timer
+++ b/services/gitlab-network-ip.timer
@@ -5,7 +5,10 @@ Requires=gitlab.service
 After=gitlab.service
 
 [Timer]
-OnUnitActiveSec=5
+# This case is not covered by the systemd docs, but this will run the timer every
+# 5 seconds.
+# http://dcycleproject.org/blog/112/systemd-replacement-cron-every-10-seconds
+OnCalendar=*:*:0/5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/116044571
- The OnUnitActiveSec thing only triggered once after 5secs, not recurring
- Writing constantly to the gitlab/ip skvs key triggered the subsequent haproxy restart every 5 seconds due to modified timestamp on the file, so we need additional logic here
