### PR TITLE
Make the tests work on Darwin (and possibly even Plan 9)…

### DIFF
--- a/go/netconf/glide.lock
+++ b/go/netconf/glide.lock
@@ -1,5 +1,5 @@
 hash: 8361af37f28af9ed1f34df0a407b5ea0f65447b3ad3c659d2356601b8379b376
-updated: 2016-08-25T15:36:27.912361901+02:00
+updated: 2016-09-01T17:45:26.059780827+02:00
 imports:
 - name: github.com/coreos/go-systemd
   version: d6c05a1dcbb5ac02b7653da4d99e5db340c20778
@@ -10,9 +10,9 @@ imports:
   subpackages:
   - netutil
 - name: github.com/godbus/dbus
-  version: 58b0385796c5b97c6934388174215143cbd111bf
+  version: 9998ce8520caaa4a287fa5122ecb5d1ca1aeaede
 - name: github.com/vishvananda/netlink
-  version: d710fbade461cd8e75f8d263df73cc2c9dfbe168
+  version: 63381f39fceb1c5c13503a90e1c2603caeafe3c5
   subpackages:
   - nl
 - name: github.com/vishvananda/netns

--- a/go/netconf/mocs.go
+++ b/go/netconf/mocs.go
@@ -1,0 +1,45 @@
+package main
+
+import "github.com/experimental-platform/platform-utils/netutil"
+
+type mocNL struct {
+	macAddressData        string
+	macAddressError       error
+	listOfRoutesData      []string
+	listOfRoutesError     error
+	listOfAddressesData   []string
+	listOfAddressesError  error
+	listOfInterfacesData  []string
+	listOfInterfacesError error
+}
+
+func (n mocNL) GetMacAddress(string) (string, error) {
+	return n.macAddressData, n.macAddressError
+}
+
+func (n mocNL) GetListOfRoutes(string) ([]string, error) {
+	return n.listOfRoutesData, n.listOfRoutesError
+}
+
+func (n mocNL) GetListOfAddresses(string) ([]string, error) {
+	return n.listOfAddressesData, n.listOfAddressesError
+}
+
+func (n mocNL) GetListOfInterfaces() ([]string, error) {
+	return n.listOfInterfacesData, n.listOfInterfacesError
+}
+
+// make sure the moc satisfies the interface
+var _ NetLink = (*mocNL)(nil)
+
+type mocNU struct {
+	stats    netutil.InterfaceData
+	statsErr error
+}
+
+func (n mocNU) GetInterfaceStats(name string) (netutil.InterfaceData, error) {
+	return n.stats, n.statsErr
+}
+
+// make sure realNU satisfies the NetUtil interface
+var _ NetUtil = (*mocNU)(nil)

--- a/go/netconf/netconf_test.go
+++ b/go/netconf/netconf_test.go
@@ -2,54 +2,10 @@ package main
 
 import (
 	"github.com/experimental-platform/platform-utils/netutil"
-	"github.com/vishvananda/netlink"
 	"os"
-	"net"
 	"strings"
 	"testing"
 )
-
-type mocNL struct {
-	linkByNameData netlink.Link
-	linkByNameErr  error
-	routeList      []netlink.Route
-	routeListErr   error
-	addrList       []netlink.Addr
-	addrListErr    error
-	linkList       []netlink.Link
-	linkListError  error
-}
-
-func (n mocNL) LinkByName(s string) (netlink.Link, error) {
-	return n.linkByNameData, n.linkByNameErr
-}
-
-func (n mocNL) RouteList(l netlink.Link, f int) ([]netlink.Route, error) {
-	return n.routeList, n.routeListErr
-}
-
-func (n mocNL) AddrList(l netlink.Link, f int) ([]netlink.Addr, error) {
-	return n.addrList, n.addrListErr
-}
-
-func (n mocNL) LinkList() ([]netlink.Link, error) {
-	return n.linkList, n.linkListError
-}
-
-// make sure the moc satisfies the interface
-var _ NetLink = (*mocNL)(nil)
-
-type mocNU struct {
-	stats    netutil.InterfaceData
-	statsErr error
-}
-
-func (n mocNU) GetInterfaceStats(name string) (netutil.InterfaceData, error) {
-	return n.stats, n.statsErr
-}
-
-// make sure realNU satisfies the NetUtil interface
-var _ NetUtil = (*mocNU)(nil)
 
 /*
 	Test DHCP
@@ -105,73 +61,10 @@ func TestShowConfig(t *testing.T) {
 		statsErr: nil,
 	}
 	nl = mocNL{
-		addrList: []netlink.Addr{{
-			IPNet: func() *net.IPNet {
-				_, net, _ := net.ParseCIDR("172.16.0.123/16")
-				return net
-			}(),
-			Label: "eno1", Flags: 0, Scope: 0},
-		},
-		addrListErr: nil,
-		linkByNameData: &netlink.Device{
-			LinkAttrs: netlink.LinkAttrs{
-				Index: 4, MTU: 1500, TxQLen: 1000, Name: "eno1",
-				HardwareAddr: net.HardwareAddr{0x54, 0xbe, 0xf7, 0x66, 0x2c, 0x49},
-				Flags:        0x13, ParentIndex: 0, MasterIndex: 0,
-				Namespace: interface{}(nil),
-				Alias:     "",
-				Promisc:   0},
-		},
-		linkByNameErr: nil,
-		routeList: []netlink.Route{
-			{
-				Dst:        nil,
-				Src:        net.ParseIP("172.16.10.239"),
-				Gw:         net.ParseIP("172.16.0.1"),
-				Table:      254,
-				ILinkIndex: 4,
-			},
-			{
-				ILinkIndex: 4,
-				Dst: func() *net.IPNet {
-					_, net, _ := net.ParseCIDR("172.16.0.0/16")
-					return net
-				}(),
-				Src:   net.ParseIP("172.16.10.239"),
-				Gw:    nil,
-				Table: 254,
-			},
-		},
-		routeListErr: nil,
-		linkList: []netlink.Link{
-			&netlink.Device{
-				LinkAttrs: netlink.LinkAttrs{
-					Index: 4, MTU: 1500, TxQLen: 1000, Name: "enototallyyourdevice1",
-					HardwareAddr: net.HardwareAddr{0x54, 0xbe, 0xf7, 0x66, 0x2c, 0x49},
-					Flags:        0x13, ParentIndex: 0, MasterIndex: 0,
-					Namespace: interface{}(nil),
-					Alias:     "",
-					Promisc:   0},
-			},
-			&netlink.Device{
-				LinkAttrs: netlink.LinkAttrs{
-					Index: 4, MTU: 1500, TxQLen: 1, Name: "enoyoudontseeme0",
-					HardwareAddr: net.HardwareAddr{0x54, 0xbe, 0xf7, 0x66, 0x2c, 0x49},
-					Flags:        0x13, ParentIndex: 0, MasterIndex: 0,
-					Namespace: interface{}(nil),
-					Alias:     "",
-					Promisc:   0},
-			},
-			&netlink.Device{
-				LinkAttrs: netlink.LinkAttrs{
-					Index: 4, MTU: 1500, TxQLen: 1000, Name: "wl_my_home_network",
-					HardwareAddr: net.HardwareAddr{0x54, 0xbe, 0xf7, 0x66, 0x2c, 0x49},
-					Flags:        0x13, ParentIndex: 0, MasterIndex: 0,
-					Namespace: interface{}(nil),
-					Alias:     "",
-					Promisc:   0},
-			},
-		},
+		listOfAddressesData:  []string{"172.16.0.123/16"},
+		listOfInterfacesData: []string{"eno0", "eno1", "enototallyyourdevice1"},
+		listOfRoutesData:     []string{"172.16.0.1"},
+		macAddressData:       "0a:66:7f:12:8d:15",
 	}
 	result, err := switchByCommandline()
 	if err != nil {
@@ -200,3 +93,8 @@ func TestShowConfig(t *testing.T) {
 */
 
 // TODO: make sure every menu item starts the correct functions.
+
+/*
+	TEST LINUX
+*/
+// TODO: make sure that on Linux the real NetLink and NetUtil are compiled in...

--- a/go/netconf/netlink_linux.go
+++ b/go/netconf/netlink_linux.go
@@ -1,0 +1,90 @@
+// +build linux amd64
+
+package main
+
+import (
+	"fmt"
+	"github.com/experimental-platform/platform-utils/netutil"
+	"github.com/vishvananda/netlink"
+	"strings"
+)
+
+// TODO: important: This can only be tested on linux!
+
+type realNL struct {
+}
+
+func (n realNL) GetMacAddress(name string) (string, error) {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return "", err
+	}
+	// add hardware address
+	linkAttrs := link.Attrs()
+	return linkAttrs.HardwareAddr.String(), err
+}
+
+func (n realNL) GetListOfRoutes(name string) ([]string, error) {
+	var result []string
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return result, err
+	}
+	routeList, err := netlink.RouteList(link, netlink.FAMILY_V4)
+	if err != nil && len(routeList) < 1 {
+		return result, err
+	}
+	for _, route := range routeList {
+		if route.Gw != nil {
+			result = append(result, route.Gw.String())
+		}
+	}
+	return result, nil
+}
+
+func (n realNL) GetListOfAddresses(name string) ([]string, error) {
+	var result []string
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return result, err
+	}
+	addrList, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		return result, err
+	}
+	for _, addr := range addrList {
+		result = append(result, fmt.Sprintf("%s", addr.IPNet))
+	}
+	return result, nil
+}
+
+func (n realNL) GetListOfInterfaces() ([]string, error) {
+	result := []string{}
+	linkList, err := netlink.LinkList()
+	if err != nil {
+		return result, err
+	}
+	for _, entry := range linkList {
+		attrs := entry.Attrs()
+		// all hardware interfaces (NOT their aliases) have a TxQLen > 1
+		if attrs.TxQLen > 1 && !strings.HasPrefix(attrs.Name, "wl") {
+			result = append(result, attrs.Name)
+		}
+	}
+	return result, err
+}
+
+// make sure realNL satisfies the NetLink interface
+var _ NetLink = (*realNL)(nil)
+var nl NetLink = realNL{}
+
+type realNU struct {
+}
+
+func (n realNU) GetInterfaceStats(name string) (netutil.InterfaceData, error) {
+	return netutil.GetInterfaceStats(name)
+}
+
+// make sure realNU satisfies the NetUtil interface
+var _ NetUtil = (*realNU)(nil)
+var nu NetUtil = realNU{}

--- a/go/netconf/netlink_other.go
+++ b/go/netconf/netlink_other.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package main
+
+// default is mock, so we can run on Darwin and Windows without killing those.
+var nl NetLink = mocNL{}
+var nu NetUtil = mocNU{}


### PR DESCRIPTION
… by architecture dependent compilation. Technically, this enabled building the binary on platforms other than Linux. Since all these platforms don't have the Linux kernels netlink, that doesn't make much sense. Binaries produced in such a way will behave erratically and might even damage the system.
