### PR TITLE
Make mysql create new databases in utf8_unicode_ci

### DIFF
--- a/services/mysql.service
+++ b/services/mysql.service
@@ -18,7 +18,9 @@ ExecStartPre=/usr/bin/docker run -d \
     --name=mysql \
     -e "MYSQL_ROOT_PASSWORD=s3kr3t" \
     -e "MYSQL_DATABASE=german-shepherd" \
-  quay.io/experimentalplatform/mysql:{{tag}}
+    quay.io/experimentalplatform/mysql:{{tag}} \
+    --character-set-server=utf8 \
+    --collation-server=utf8_unicode_ci
 ExecStart=/usr/bin/docker logs -f mysql
 ExecStop=/usr/bin/docker stop mysql
 ExecStopPost=/usr/bin/docker stop mysql


### PR DESCRIPTION
As per https://github.com/docker-library/docs/pull/502#issuecomment-188530080 - configures mysql default charsets and hence the encoding of newly created databases.

Verified it works as expected using the sample query from the mentioned issue (`SELECT schema_name, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM INFORMATION_SCHEMA.SCHEMATA;`) on a test box, works fine
