### PR TITLE
soul-prepare unit tweaks

### DIFF
--- a/services/soul-prepare.service
+++ b/services/soul-prepare.service
@@ -26,7 +26,9 @@ ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
                --volume /data/hardware:/tmp/hardware \
                quay.io/protonetinc/german-shepherd:{{tag}} \
                bundle exec rake docker:prepare"
-ExecStart=/usr/bin/env true
+ExecStart=/usr/bin/docker logs -f soul-prepare
+ExecStop=/usr/bin/docker stop soul-prepare
+ExecStopPost=/usr/bin/docker stop soul-prepare
 
 [Install]
 WantedBy=multi-user.target

--- a/services/soul-prepare.service
+++ b/services/soul-prepare.service
@@ -13,8 +13,9 @@ RemainAfterExit=yes
 ExecStartPre=/bin/mkdir -p /data/soul
 ExecStartPre=/opt/bin/rabbitmq-manager -create german-shepherd
 ExecStartPre=-/usr/bin/docker rm -f soul-prepare
-ExecStartPre=/usr/bin/docker run -d \
+ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
                --net=protonet \
+               --env \"RABBITMQ_URL=$(/opt/bin/skvs_cli get app/german-shepherd/rabbitmq)\" \
                --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
                --volume /data/soul/samba_includes:/home/protonet/dashboard/shared/samba_includes/ \
                --volume /data/soul/trash:/home/protonet/dashboard/shared/trash/ \
@@ -24,7 +25,7 @@ ExecStartPre=/usr/bin/docker run -d \
                --volume /data/hardware:/tmp/hardware \
                --name soul-prepare \
                quay.io/protonetinc/german-shepherd:{{tag}} \
-               bundle exec rake docker:prepare
+               bundle exec rake docker:prepare"
 ExecStart=/usr/bin/env true
 
 [Install]

--- a/services/soul-prepare.service
+++ b/services/soul-prepare.service
@@ -14,6 +14,7 @@ ExecStartPre=/bin/mkdir -p /data/soul
 ExecStartPre=/opt/bin/rabbitmq-manager -create german-shepherd
 ExecStartPre=-/usr/bin/docker rm -f soul-prepare
 ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
+               --name soul-prepare \
                --net=protonet \
                --env \"RABBITMQ_URL=$(/opt/bin/skvs_cli get app/german-shepherd/rabbitmq)\" \
                --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
@@ -23,7 +24,6 @@ ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
                --volume /data/soul/public:/home/protonet/dashboard/shared/public/ \
                --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
                --volume /data/hardware:/tmp/hardware \
-               --name soul-prepare \
                quay.io/protonetinc/german-shepherd:{{tag}} \
                bundle exec rake docker:prepare"
 ExecStart=/usr/bin/env true


### PR DESCRIPTION
This is a followup to https://www.pivotaltracker.com/story/show/131807459

Also, the rabbitmq_url thing is important since right now it is working, but I believe "accidentally" (because the guest:guest account hardcoded into the soul docker image is present on machines, and hence it keeps working). So, once the default account is removed, soul-prepare would wait for rabbitmq to be reachable into infinty, and it'll never start soul.
