### PR TITLE
Unify soul file mountpoints into a single top-level one wherever neccessary

### DIFF
--- a/services/smb-protonet.service
+++ b/services/smb-protonet.service
@@ -20,10 +20,7 @@ ExecStartPre=-/usr/bin/docker rm -f smb
 ExecStartPre=/usr/bin/docker run -d \
     --name=smb \
     --net=host \
-    --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
-    --volume /data/soul/samba_includes:/home/protonet/dashboard/shared/samba_includes/ \
-    --volume /data/soul/trash:/home/protonet/dashboard/shared/trash/ \
-    --volume /data/soul/log:/home/protonet/dashboard/shared/log/ \
+    --volume /data/soul:/home/protonet/dashboard/shared/ \
     --volume /data/samba/etc-mounted:/etc/samba/ \
     --volume /data/samba/extrausers:/var/lib/extrausers/ \
     quay.io/protonetinc/soul-smb:{{tag}}

--- a/services/soul-dispatcher.service
+++ b/services/soul-dispatcher.service
@@ -17,12 +17,7 @@ ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
   --name soul-dispatcher \
   --net=protonet \
   --env \"RABBITMQ_URL=$(/opt/bin/skvs_cli get app/german-shepherd/rabbitmq)\" \
-  --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
-  --volume /data/soul/samba_includes:/home/protonet/dashboard/shared/samba_includes/ \
-  --volume /data/soul/trash:/home/protonet/dashboard/shared/trash/ \
-  --volume /data/soul/log:/home/protonet/dashboard/shared/log/ \
-  --volume /data/soul/public:/home/protonet/dashboard/shared/public/ \
-  --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
+  --volume /data/soul:/home/protonet/dashboard/shared/ \
   --volume /data/samba/etc:/etc/samba/ \
   --volume /data/samba/extrausers:/var/lib/extrausers/ \
   --volume /data/hardware:/tmp/hardware \

--- a/services/soul-fs-notifier.service
+++ b/services/soul-fs-notifier.service
@@ -15,7 +15,7 @@ ExecStartPre=-/usr/bin/docker rm -f soul-fs-notifier
 ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
   --name soul-fs-notifier \
   --net=protonet \
-  --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
+  --volume /data/soul:/home/protonet/dashboard/shared/ \
   --env \"RABBITMQ_URL=$(/opt/bin/skvs_cli get app/german-shepherd/rabbitmq)\" \
   quay.io/protonetinc/german-shepherd:{{tag}} \
   bundle exec foreman start fs_notifier"

--- a/services/soul-nginx.service
+++ b/services/soul-nginx.service
@@ -14,9 +14,7 @@ ExecStartPre=-/usr/bin/docker rm -f soul-nginx
 ExecStartPre=/usr/bin/docker run -d \
     --name soul-nginx \
     --net=protonet \
-    --volume /data/soul/public:/home/protonet/dashboard/shared/public/ \
-    --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
-    --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
+    --volume /data/soul:/home/protonet/dashboard/shared/ \
     quay.io/protonetinc/soul-nginx:{{tag}}
 ExecStart=/usr/bin/docker logs -f soul-nginx
 ExecStop=/usr/bin/docker stop soul-nginx

--- a/services/soul-owner.service
+++ b/services/soul-owner.service
@@ -14,12 +14,7 @@ ExecStartPre=-/usr/bin/docker rm -f soul-owner
 ExecStartPre=/usr/bin/docker run -d \
       --name soul-owner \
       --net=protonet \
-      --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
-      --volume /data/soul/samba_includes:/home/protonet/dashboard/shared/samba_includes/ \
-      --volume /data/soul/trash:/home/protonet/dashboard/shared/trash/ \
-      --volume /data/soul/log:/home/protonet/dashboard/shared/log/ \
-      --volume /data/soul/public:/home/protonet/dashboard/shared/public/ \
-      --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
+      --volume /data/soul:/home/protonet/dashboard/shared/ \
       quay.io/protonetinc/soul-owner:{{tag}}
 ExecStart=/usr/bin/docker logs -f soul-owner
 ExecStop=/usr/bin/docker stop soul-owner

--- a/services/soul-prepare.service
+++ b/services/soul-prepare.service
@@ -17,12 +17,7 @@ ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
                --name soul-prepare \
                --net=protonet \
                --env \"RABBITMQ_URL=$(/opt/bin/skvs_cli get app/german-shepherd/rabbitmq)\" \
-               --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
-               --volume /data/soul/samba_includes:/home/protonet/dashboard/shared/samba_includes/ \
-               --volume /data/soul/trash:/home/protonet/dashboard/shared/trash/ \
-               --volume /data/soul/log:/home/protonet/dashboard/shared/log/ \
-               --volume /data/soul/public:/home/protonet/dashboard/shared/public/ \
-               --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
+               --volume /data/soul:/home/protonet/dashboard/shared/ \
                --volume /data/hardware:/tmp/hardware \
                quay.io/protonetinc/german-shepherd:{{tag}} \
                bundle exec rake docker:prepare"

--- a/services/soul-web.service
+++ b/services/soul-web.service
@@ -15,12 +15,7 @@ ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
       --name soul-web \
       --net=protonet \
       --env \"RABBITMQ_URL=$(/opt/bin/skvs_cli get app/german-shepherd/rabbitmq)\" \
-      --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
-      --volume /data/soul/samba_includes:/home/protonet/dashboard/shared/samba_includes/ \
-      --volume /data/soul/trash:/home/protonet/dashboard/shared/trash/ \
-      --volume /data/soul/log:/home/protonet/dashboard/shared/log/ \
-      --volume /data/soul/public:/home/protonet/dashboard/shared/public/ \
-      --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
+      --volume /data/soul:/home/protonet/dashboard/shared/ \
       --volume /data/samba/etc:/etc/samba/ \
       --volume /data/samba/extrausers:/var/lib/extrausers/ \
       --volume /data/hardware:/tmp/hardware \

--- a/services/soul-webdav.service
+++ b/services/soul-webdav.service
@@ -17,9 +17,7 @@ ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
     --user webdav \
     --hostname soul-webdav \
     --env \"RABBITMQ_URL=$(/opt/bin/skvs_cli get app/german-shepherd/rabbitmq)\" \
-    --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
-    --volume /data/soul/trash:/home/protonet/dashboard/shared/trash/ \
-    --volume /data/soul/log:/home/protonet/dashboard/shared/log/ \
+    --volume /data/soul:/home/protonet/dashboard/shared/ \
     quay.io/protonetinc/german-shepherd:{{tag}} \
     bundle exec foreman start webdav"
 ExecStart=/usr/bin/docker logs -f soul-webdav

--- a/services/soul-worker.service
+++ b/services/soul-worker.service
@@ -15,12 +15,7 @@ ExecStartPre=/usr/bin/env bash -c "/usr/bin/docker run -d \
     --name soul-worker \
     --net=protonet \
     --env \"RABBITMQ_URL=$(/opt/bin/skvs_cli get app/german-shepherd/rabbitmq)\" \
-    --volume /data/soul/files:/home/protonet/dashboard/shared/files/ \
-    --volume /data/soul/samba_includes:/home/protonet/dashboard/shared/samba_includes/ \
-    --volume /data/soul/trash:/home/protonet/dashboard/shared/trash/ \
-    --volume /data/soul/log:/home/protonet/dashboard/shared/log/ \
-    --volume /data/soul/public:/home/protonet/dashboard/shared/public/ \
-    --volume /data/soul/uploads:/home/protonet/dashboard/shared/uploads/ \
+    --volume /data/soul:/home/protonet/dashboard/shared/ \
     --volume /data/samba/etc:/etc/samba/ \
     --volume /data/samba/extrausers:/var/lib/extrausers/ \
     --volume /data/hardware:/tmp/hardware \


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/132744909

tl;dr: Moving files between the individual mountpoints of volumes is slow because within the container obviously it's not visible that on the host system, the same filesystem underlies these folders.

There is also no specific reason that these mountpoints should be done separately, it just evolved into this by adding each individual mountpoint step by step as we were building out. Luckily, the actual directory structure at the expected mountpoint within all the containers is the same as on the host (otherwise this would obviously not have been possible)

