### PR TITLE
Always run the PTW client if soul is enabled now that SSH tunnel itself is optional instead

### DIFF
--- a/services/ptw-protonet.service
+++ b/services/ptw-protonet.service
@@ -3,7 +3,7 @@
 Description=Run 'ptw' service
 After=skvs-protonet.service
 Requires=skvs-protonet.service
-ConditionPathExists=/etc/protonet/ptw/control/enabled
+ConditionPathExists=/etc/protonet/soul/enabled
 
 [Service]
 TimeoutStartSec=0


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/133910945

A close relative of https://github.com/experimental-platform/platform-ptw/pull/20
