### PR TITLE
drop permissive udev rules for media devices

### DIFF
--- a/config/sound-permissions.rules
+++ b/config/sound-permissions.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="sound", MODE="0666"

--- a/config/tty-permissions.rules
+++ b/config/tty-permissions.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="tty", MODE="0666"

--- a/config/video-permissions.rules
+++ b/config/video-permissions.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="video4linux", MODE="0666"

--- a/prep.sh
+++ b/prep.sh
@@ -250,9 +250,6 @@ function remove_old_images() {
 
 function setup_udev() {
     echo -n "Setting up UDEV rules..."
-    cp /config/sound-permissions.rules ${MOUNTROOT}/etc/udev/rules.d/sound-permissions.rules
-    cp /config/video-permissions.rules ${MOUNTROOT}/etc/udev/rules.d/video-permissions.rules
-    cp /config/tty-permissions.rules   ${MOUNTROOT}/etc/udev/rules.d/tty-permissions.rules
     cp /config/80-protonet.rules   ${MOUNTROOT}/etc/udev/rules.d/80-protonet.rules
     udevadm control --reload-rules || true
     echo "DONE."


### PR DESCRIPTION
this was used in the days of old experimental-platform for dokku-based IoT apps