### PR TITLE
Raise journal storage size limit

### DIFF
--- a/config/journald_protonet.conf
+++ b/config/journald_protonet.conf
@@ -9,7 +9,7 @@
 #SyncIntervalSec=5m
 #RateLimitInterval=30s
 #RateLimitBurst=1000
-SystemMaxUse=1G
+SystemMaxUse=4G
 # SystemKeepFree=2G
 SystemMaxFileSize=100M
 RuntimeMaxUse=50M


### PR DESCRIPTION
1 GB has proven to be a little small.
on highly active customer boxes the journal barely holds more than 24h of journal.

I would like to raise the limit to 4GB
Is that okay with you @kdomanski @colszowka ?